### PR TITLE
Missing ts-node from dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "typescript": "^4.4.3"
   },
   "dependencies": {
-    "@grpc/grpc-js": "^1.3.7"
+    "@grpc/grpc-js": "^1.3.7",
+    "ts-node": "^10.9.1"
   }
 }


### PR DESCRIPTION
This fixes an issue when running with npm where nodemon could not find ts-node.